### PR TITLE
Refactor landing

### DIFF
--- a/components/organism/carousel/ReviewsCarousel.vue
+++ b/components/organism/carousel/ReviewsCarousel.vue
@@ -1,15 +1,21 @@
 <script setup>
 const { t } = useI18n()
 const { clientReviews } = useClientReviews()
+defineProps({
+  isHome: {
+    type: Boolean,
+    default: false,
+  },
+});
 </script>
 
 <template>
-  <div class="card">
+  <div>
     <Carousel
       :value="clientReviews"
       :num-visible="1"
       :num-scroll="1"
-      class="carousel-color"
+      :class="['carousel-color', { 'carousel--home': isHome }]"
       circular
     >
       <template #item="slotProps">
@@ -19,8 +25,8 @@ const { clientReviews } = useClientReviews()
           <div class="pt-4 row">
             <img
               :src="slotProps.data.src"
-              height="60%"
-              width="60%"
+              height="100%"
+              width="100%"
               class="img-border"
             >
 
@@ -77,10 +83,6 @@ const { clientReviews } = useClientReviews()
   &:deep(.p-carousel-item){
     // flex: 1 0 100% !important;
   }
-}
-.comment-text {
-  font-size: 1.5rem;
-}
 
 .border {
   display: flex;
@@ -90,19 +92,54 @@ const { clientReviews } = useClientReviews()
 }
 
 .comment-text {
-  flex: 1; 
   font-size: 1.5rem;
 }
 @media only screen and (max-width: 600px) {
   .border {
     display: block; 
-    align-items: center;
-    justify-content: center;
     gap: 1rem; 
   }
   .img-border{
+    width: 40%;
+    height: 40%;
     display: flex;
     margin: auto;
+  }
+  .comment-text {
+      font-size: 1rem;
+    }
+    .font-size-text{
+      font-size: 1.2rem !important;
+    }
+}
+}
+//Estilos para el home, solo se aplican cuando se envia una prop verdadera como en el ContactUs
+//cuando se lo llama desde el home
+.carousel--home{
+  .img-border {
+    width: 40%;
+    height: 40%;
+    display: flex;
+    margin: auto;
+    border-radius: 100%;
+  }
+ 
+  .comment-text {
+    font-size: 1.5rem;
+  }
+  .border {
+    display: grid;
+    flex-direction: row; 
+    align-items: center;
+    gap: 1rem; 
+  }
+  @media only screen and (max-width: 600px) {
+    .comment-text {
+      font-size: 0.8rem;
+    }
+    .font-size-text{
+      font-size: 1rem !important;
+    }
   }
 }
 </style>

--- a/components/organism/section/ContactUs.vue
+++ b/components/organism/section/ContactUs.vue
@@ -2,11 +2,14 @@
 import { useViewport } from '~/composables/useViewport';
 import { useToast } from 'primevue/usetoast';
 import { isRequired, isValidEmail, isValidPhone, minLength } from '~/constants/fieldErrors';
+import { useRoute } from 'vue-router';
 
 const { t } = useI18n()
 const { isSmaller: isMobile } = useViewport('lg');
 const router = useRouter();
 const toast = useToast();
+const route = useRoute();
+const isHomePage = computed(() => route.path === '/');
 
 const fields = ref([
   {
@@ -94,9 +97,18 @@ const sendEmail = async (formData) => {
         </div>
       </div>
       <div
-        class="flex flex-row gap-4 justify-content-center"
-        :class="{ 'flex-column-reverse align-items-center': isMobile }"
+        class="flex flex-row gap-4"
+        :class="{ 
+          'justify-between': isHomePage,
+          'justify-content-center': !isHomePage,
+          'flex-column-reverse align-items-center': isMobile }"
       >
+        <div 
+          v-if="isHomePage" 
+          class="carousel"
+        >
+          <ReviewsCarousel :is-home="true" />
+        </div>
         <div class="contact-card">
           <Card>
             <template #content>
@@ -135,13 +147,15 @@ const sendEmail = async (formData) => {
   &:deep(.p-card-body){
     padding: 32px;
   }
+  
 }
-.carrousel-container {
-  width: 100%;
-  max-width: 625px;
-  margin: 0 auto;
-  @media (min-width: 1080px) {
-    margin: 0;
+
+.carousel{
+  width: 60%;
+}
+@media only screen and (max-width: 1080px) {
+  .carousel{
+    width: 100%;
   }
 }
 </style>


### PR DESCRIPTION
Se volvio a colocar los comentarios de los clientes en el home con sus respectivos estilos, cuando se llama desde otra url no se muestran los comentarios de los clientes, solo el formulario:
En la pagina de clientes se mantienen los comentarios
![image](https://github.com/user-attachments/assets/25454169-037b-4871-a0c1-28742abb418c)
En la parte final de todas las paginas menos home se muestra el formulario:
![image](https://github.com/user-attachments/assets/2383d2b7-03f5-4c24-bb29-e239a32827bf)
Y en el Home se muestra de esta forma:
![image](https://github.com/user-attachments/assets/5c324081-7888-40fb-a5fd-3b68245e1b6b)
