### PR TITLE
fix styles responsive in range 960 to 1080

### DIFF
--- a/assets/css/_theme.scss
+++ b/assets/css/_theme.scss
@@ -4651,7 +4651,7 @@
   margin: 1.5rem 0;
 }
 
-@media screen and (max-width: 960px) {
+@media screen and (max-width: 1080px) {
   .p-dock.p-dock-top .p-dock-list-container, .p-dock.p-dock-bottom .p-dock-list-container {
     overflow-x: auto;
     width: 100%;
@@ -4980,7 +4980,7 @@
   font-size: 0.875rem;
 }
 
-@media screen and (max-width: 960px) {
+@media screen and (max-width: 1080px) {
   .p-menubar {
     position: relative;
   }

--- a/components/organism/section/Header.vue
+++ b/components/organism/section/Header.vue
@@ -142,7 +142,7 @@ const scrollToSection = (id) => {
     margin-top: 12px;
     border-radius: 8px;
     width: initial;
-    @media (max-width: 960px) {
+    @media (max-width: 1080px) {
       position: relative;
       margin-top: 0px;
       margin-bottom: 16px;
@@ -200,7 +200,7 @@ const scrollToSection = (id) => {
     transition: all .5s ease-in-out;
     z-index: 1 !important;
     animation: fadeIn .5s ease-in-out forwards;
-    @media (max-width: 960px) {
+    @media (max-width: 1080px) {
       margin-top: 0px;
     }
   }
@@ -218,7 +218,7 @@ const scrollToSection = (id) => {
   &:deep(.p-menuitem) {
     .flag {
       margin-top: 5px;
-      @media (max-width: 960px) {
+      @media (max-width: 1080px) {
         margin-top: 0px;
       }
     }
@@ -226,7 +226,7 @@ const scrollToSection = (id) => {
   &:deep(.p-menuitem-content) {
     border-radius: 8px;
     margin: 0 4px;
-    @media (max-width: 960px) {
+    @media (max-width: 1080px) {
       margin-top: 16px;
       margin-bottom: 16px;
       margin-left: 16px;
@@ -238,7 +238,7 @@ const scrollToSection = (id) => {
     width: 4rem;
     height: 4rem;
   }
-  @media (min-width: 961px) {
+  @media (min-width: 1081px) {
     align-items: center;
     padding: 0.5rem;
     background: var(--surface-b);


### PR DESCRIPTION
Se corrigieron los estilos del header que se rompian en el rango de 960 a 1080, anteriormente sucedia esto:
![image](https://github.com/user-attachments/assets/fb807c29-42e2-444b-bb13-5c3798bdfe68)
y ahora se cambio a esto:
![image](https://github.com/user-attachments/assets/823e0c1e-c2e8-4e7c-b96f-58c81150072c)
![image](https://github.com/user-attachments/assets/7e3928a7-bbfa-4572-a32d-5677bb8d6c83)
![image](https://github.com/user-attachments/assets/aecb299a-abd0-4744-87cd-d3d35be31be0)
![image](https://github.com/user-attachments/assets/924b90f2-3126-473c-b3fa-cba1c24096d7)
